### PR TITLE
Make arguments unique after merging arrays

### DIFF
--- a/ExifToolBatch.php
+++ b/ExifToolBatch.php
@@ -259,7 +259,7 @@ class ExifToolBatch {
 
     public function execute($args){
         // merge default args with supplied args
-        $argsmerged=array_merge($this->_defargs,$args);
+        $argsmerged=array_unique(array_merge($this->_defargs,$args));
         return $this->execute_args($argsmerged);
     }
 


### PR DESCRIPTION
When calling add() with default arguments (as in the readme example) they get duplicated, because array_merge does not overwrite arrays with numeric keys.